### PR TITLE
make and use confirm-features custom element

### DIFF
--- a/demo/loadmore.html
+++ b/demo/loadmore.html
@@ -28,6 +28,7 @@
       height: 80px;
     }
   </style>
+  <script type="module" src="./util/confirm-features.mjs"></script>
 </head>
 
 <body>
@@ -42,9 +43,6 @@
     // Do this separately. If virtual-scroller is not available, the demo
     // will still work.
     import 'std:elements/virtual-scroller';
-  </script>
-  <script type="module">
-    import * as confirmFeatures from './util/confirm-features.mjs';
   </script>
   <script type="module">
     import './contacts/contact-element.mjs';

--- a/demo/loadmore.html
+++ b/demo/loadmore.html
@@ -31,7 +31,7 @@
 </head>
 
 <body>
-  <div id=errors></div>
+  <confirm-features></confirm-features>
   <div>
     <button id=swapButton>switch virtual-scroller &lt;-&gt; div</button>
   </div>
@@ -45,7 +45,6 @@
   </script>
   <script type="module">
     import * as confirmFeatures from './util/confirm-features.mjs';
-    confirmFeatures.confirm(errors);
   </script>
   <script type="module">
     import './contacts/contact-element.mjs';

--- a/demo/util/confirm-features.mjs
+++ b/demo/util/confirm-features.mjs
@@ -8,18 +8,22 @@ function redP(textContent) {
 /**
  * Checks that the features needed are present in the browser. If not,
  * it places error messages inside |element|.
-
  **/
-export function confirm(element) {
-  if (element.displayLock === undefined) {
-    element.appendChild(redP('Display Locking is not available'));
-  }
+class ConfirmFeatures extends HTMLElement {
+  constructor() {
+    super();
+    if (this.displayLock === undefined) {
+      this.appendChild(redP('Display Locking is not available'));
+    }
 
-  if (!customElements.get('virtual-scroller')) {
-    const div = redP('virtual-scroller is not available');
-    element.appendChild(div);
-    customElements.whenDefined('virtual-scroller').then(() => {
-      div.remove();
-    });
+    if (!customElements.get('virtual-scroller')) {
+      const div = redP('virtual-scroller is not available');
+      this.appendChild(div);
+      customElements.whenDefined('virtual-scroller').then(() => {
+        div.remove();
+      });
+    }
   }
 }
+
+customElements.define('confirm-features', ConfirmFeatures);


### PR DESCRIPTION
Turn the code of confirm-features.mjs into a custom element to make it trivial to reuse in all demos.